### PR TITLE
decouple low-level HTTP implementation from SDWebService - take two

### DIFF
--- a/Source/WebServices/SDURLConnection.h
+++ b/Source/WebServices/SDURLConnection.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "SDWebServiceTask.h"
 
 /**
  SDURLConnection is a subclass of NSURLConnection that manages the concurrency and queueing of multiple asynchronous connections.
@@ -21,7 +22,7 @@
 
 typedef void (^SDURLConnectionResponseBlock)(SDURLConnection *connection, NSURLResponse *response, NSData *responseData, NSError *error);
 
-@interface SDURLConnection : NSURLConnection
+@interface SDURLConnection : NSURLConnection <SDWebServiceTask>
 
 /**
  Returns the maximum number of concurrent connections allowed.

--- a/Source/WebServices/SDWebService.h
+++ b/Source/WebServices/SDWebService.h
@@ -9,6 +9,7 @@
 #import "SDURLConnection.h"
 #import "Reachability.h"
 #import "SDWebServiceMockResponseProvider.h"
+#import "SDWebServiceTask.h"
 
 typedef id (^SDWebServiceDataCompletionBlock)(NSURLResponse *response, NSInteger responseCode, NSData *responseData, NSError *error);
 typedef void (^SDWebServiceUICompletionBlock)(id dataObject, NSError *error);

--- a/Source/WebServices/SDWebService.m
+++ b/Source/WebServices/SDWebService.m
@@ -654,7 +654,7 @@ NSString *const SDWebServiceError = @"SDWebServiceError";
     NSDate *startDate = [NSDate date];
 #endif
 
-	SDURLConnectionResponseBlock urlCompletionBlock = ^(SDURLConnection *connection, NSURLResponse *response, NSData *responseData, NSError *error) {
+	SDWebServiceTaskCompletionBlock urlCompletionBlock = ^(id<SDWebServiceTask> task, NSURLResponse *response, NSData *responseData, NSError *error) {
 #ifdef DEBUG
         NSTimeInterval interval = [[NSDate date] timeIntervalSinceDate:startDate];
         if (interval)           // This is a DEBUG mode workaround for SDLog() being defined but empty in Unit Test builds.
@@ -679,7 +679,7 @@ NSString *const SDWebServiceError = @"SDWebServiceError";
 
                     @synchronized(self) { // NSMutableDictionary isn't thread-safe
                         // do some sync/cleanup stuff here.
-                        SDURLConnection *newConnection = [_normalRequests objectForKey:newObject.identifier];
+                        id<SDWebServiceTask> newConnection = [_normalRequests objectForKey:newObject.identifier];
                         
                         // If for some unknown reason the second performRequestWithMethod hits the cache, then we'll get a nil identifier, which means a nil newConnection
                         if (newConnection)
@@ -780,11 +780,11 @@ NSString *const SDWebServiceError = @"SDWebServiceError";
         if (singleRequest)
         {
             @synchronized(self) {
-                SDURLConnection *existingConnection = [_singleRequests objectForKey:requestName];
-                if (existingConnection)
+                id<SDWebServiceTask> existingTask = [_singleRequests objectForKey:requestName];
+                if (existingTask)
                 {
                     SDLog(@"Cancelling call.");
-                    [existingConnection cancel];
+                    [existingTask cancel];
                     [_singleRequests removeObjectForKey:requestName];
                 }
             }
@@ -794,14 +794,13 @@ NSString *const SDWebServiceError = @"SDWebServiceError";
     if (!mockData)
     {
         // no mock data was found, or we don't want to use mocks.  send out the request.
-
-        SDURLConnection *connection = [SDURLConnection sendAsynchronousRequest:request withResponseHandler:urlCompletionBlock];
-
+        id<SDWebServiceTask> task = [self sendAsynchronousRequest:request handler:urlCompletionBlock];
+        
         @synchronized(self) {
             if (singleRequest)
-                [_singleRequests setObject:connection forKey:requestName];
+                [_singleRequests setObject:task forKey:requestName];
             else
-                [_normalRequests setObject:connection forKey:identifier];
+                [_normalRequests setObject:task forKey:identifier];
         }
     }
     else
@@ -826,8 +825,8 @@ NSString *const SDWebServiceError = @"SDWebServiceError";
 - (void)cancelRequestForIdentifier:(NSString *)identifier
 {
     @synchronized(self) {
-        SDURLConnection *connection = [_normalRequests objectForKey:identifier];
-        [connection cancel];
+        id<SDWebServiceTask> task = [_normalRequests objectForKey:identifier];
+        [task cancel];
     }
 }
 
@@ -879,6 +878,27 @@ NSString *const SDWebServiceError = @"SDWebServiceError";
      */
 
     return FALSE;
+}
+
+#pragma mark - SDWebServiceTask
+
+- (id<SDWebServiceTask>)sendAsynchronousRequest:(NSURLRequest *)request
+                                        handler:(SDWebServiceTaskCompletionBlock)handler {
+    // use service task factory when conforming to factory protocol
+    if ([self conformsToProtocol:@protocol(SDWebServiceTaskFactory)]) {
+        id<SDWebServiceTaskFactory> factory = (id <SDWebServiceTaskFactory>)self;
+        return [factory serviceTaskWithRequest:request handler:handler];
+    }
+    
+    // default to SDURLConnection for sending requests when no
+    // SDWebServiceTaskFactory implementation is provided
+    return [self connectionWithRequest:request handler:handler];
+}
+
+#pragma mark - SDURLConnection
+
+- (SDURLConnection *)connectionWithRequest:(NSURLRequest *)request handler:(SDURLConnectionResponseBlock)handler {
+    return [SDURLConnection sendAsynchronousRequest:request withResponseHandler:handler];
 }
 
 #pragma mark - Unit Testing
@@ -949,6 +969,5 @@ NSString *const SDWebServiceError = @"SDWebServiceError";
 }
 
 #endif
-
 
 @end

--- a/Source/WebServices/SDWebServiceTask.h
+++ b/Source/WebServices/SDWebServiceTask.h
@@ -1,0 +1,30 @@
+//
+//  SDWebServiceTask.h
+//  ios-shared
+//
+//  Created by Angelo Di Paolo on 2/5/16.
+//  Copyright © 2016 SetDirection. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+/// Defines an interface for managing the lifetime of a HTTP request.
+@protocol SDWebServiceTask <NSObject>
+
+/// Cancel the request.
+- (void)cancel;
+
+@end
+
+// MARK: - SDWebServiceTask Handler Block
+
+typedef void (^SDWebServiceTaskCompletionBlock)(id<SDWebServiceTask> task, NSURLResponse *response, NSData *data, NSError *error);
+
+// MARK: - SDWebServiceTaskFactory
+
+/// Defines an interface for sending asynchronous requests and handling the response.
+@protocol SDWebServiceTaskFactory <NSObject>
+
+- (id<SDWebServiceTask>)serviceTaskWithRequest:(NSURLRequest *)request
+                                       handler:(SDWebServiceTaskCompletionBlock)handler;
+@end

--- a/ios-shared.xcodeproj/project.pbxproj
+++ b/ios-shared.xcodeproj/project.pbxproj
@@ -325,6 +325,7 @@
 		00C010D01B2D69E40029C58F /* SDAccessible.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDAccessible.h; sourceTree = "<group>"; };
 		08EFCA2118FDCB70006547E0 /* NSDate+SDExtensionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDate+SDExtensionsTests.m"; sourceTree = "<group>"; };
 		08EFCA2718FEFAC6006547E0 /* NSDictionary+SDExtensionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+SDExtensionsTests.m"; sourceTree = "<group>"; };
+		173351261C652C8E00EEE5F0 /* SDWebServiceTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDWebServiceTask.h; sourceTree = "<group>"; };
 		2008D378188DAA9700255BC4 /* SDApplication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDApplication.h; sourceTree = "<group>"; };
 		2008D379188DAA9700255BC4 /* SDApplication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDApplication.m; sourceTree = "<group>"; };
 		201BC1251A79C2BF0095957D /* SDAssert.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDAssert.m; sourceTree = "<group>"; };
@@ -949,6 +950,7 @@
 				CA0E776218284DD600B4398F /* SDWebService+SDProcessingBlocks.m */,
 				CA0E776318284DD600B4398F /* SDWebService.h */,
 				CA0E776418284DD600B4398F /* SDWebService.m */,
+				173351261C652C8E00EEE5F0 /* SDWebServiceTask.h */,
 				F8BD64D41A3F445B0090D65E /* SDWebServiceMockResponseProvider.h */,
 				F8BD64D51A3F45B80090D65E /* SDWebServiceMockResponseQueueProvider.h */,
 				F8BD64D61A3F45B80090D65E /* SDWebServiceMockResponseQueueProvider.m */,


### PR DESCRIPTION
- Add `SDWebServiceTask` protocol to abstract away the interface for managing the lifetime of a request
- Added `SDWebServiceTaskFactory` protocol to abstract away the interface for sending an async NSURLRequest and handling the response/data/error completion block.
- Replace direct references to `SDURLConnection` in `SDWebService` logic with `SDWebServiceTask` protocol
- Allows the low-level HTTP implementation to be swapped out, NSURLConnection(currently in use via SDURLConnection) vs NSURLSession vs ELWebService. 
- Make `SDURLConnection` conform to `SDWebServiceTask` protocol