### PR TITLE
add `serviceTaskFactoryEnabled` to support toggling of SDWebServiceTaskFactory

### DIFF
--- a/Source/WebServices/SDWebService.h
+++ b/Source/WebServices/SDWebService.h
@@ -91,6 +91,15 @@ typedef enum
  */
 @property (nonatomic, assign) NSUInteger timeout;
 
+
+/**
+ Set to `NO` to force networking traffic to be sent through SDURLConnection.
+ Default value is `YES`. When SDWebService conforms to the `SDWebServiceTaskFactory`
+ protocol it will use the protocol's API to send requests unless the
+ `serviceTaskFactoryEnabled` property is set to `NO`.
+ */
+@property (nonatomic, assign) BOOL serviceTaskFactoryEnabled;
+
 /**
  Returns the singleton for the web service class.  This should be overridden if multiple subclasses are in use.
  */

--- a/Source/WebServices/SDWebService.m
+++ b/Source/WebServices/SDWebService.m
@@ -84,6 +84,8 @@ NSString *const SDWebServiceError = @"SDWebServiceError";
     _dataProcessingQueue.name = @"com.setdirection.dataprocessingqueue";
 
     _cookieStorage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+    
+    _serviceTaskFactoryEnabled = YES;
 
 #ifdef DEBUG
     _disableCaching = [[NSUserDefaults standardUserDefaults] boolForKey:@"kWMDisableCaching"];
@@ -885,7 +887,7 @@ NSString *const SDWebServiceError = @"SDWebServiceError";
 - (id<SDWebServiceTask>)sendAsynchronousRequest:(NSURLRequest *)request
                                         handler:(SDWebServiceTaskCompletionBlock)handler {
     // use service task factory when conforming to factory protocol
-    if ([self conformsToProtocol:@protocol(SDWebServiceTaskFactory)]) {
+    if ([self conformsToProtocol:@protocol(SDWebServiceTaskFactory)] && self.serviceTaskFactoryEnabled) {
         id<SDWebServiceTaskFactory> factory = (id <SDWebServiceTaskFactory>)self;
         return [factory serviceTaskWithRequest:request handler:handler];
     }


### PR DESCRIPTION
add `serviceTaskFactoryEnabled`property to `SDWebService` in order to support toggling off/on of sending networking traffic via SDWebServiceTaskFactory protocol