### PR TITLE
CB-4787: Fixed sorting reviews

### DIFF
--- a/IOSShared/UI/SDPickerModalViewController.m
+++ b/IOSShared/UI/SDPickerModalViewController.m
@@ -22,7 +22,7 @@
 - (id)init
 {
     if ([UIDevice bcdSystemVersion] >= 0x070000)
-        self = [super initWithNibName:@"SDPickerModalViewController-iOS7" bundle:nil];
+        self = [super initWithNibName:@"SDPickerModalViewController-iOS7" bundle:[NSBundle bundleForClass:self.class]];
     else
         self = [super initWithNibName:nil bundle:nil];
     if (self) {


### PR DESCRIPTION
Sorting reviews was broken because the nib could not be found. Since modules were separated from the main app, it is now required to look in the current bundle for the nib.