### PR TITLE
Fix compiler warnings when targeting iOS 9

### DIFF
--- a/IOSShared/Foundation/NSString+SDExtensions.m
+++ b/IOSShared/Foundation/NSString+SDExtensions.m
@@ -105,14 +105,14 @@
 
 
 - (NSString*)escapedString 
-{            
-	NSString *selfCopy = [self mutableCopy];
-	return (__bridge_transfer  NSString *) CFURLCreateStringByAddingPercentEscapes(NULL, (__bridge CFStringRef)selfCopy, NULL, CFSTR("%￼=,!$&'()*+;@?\n\"<>#\t :/"), kCFStringEncodingUTF8);
+{
+    NSCharacterSet *allowed = [NSCharacterSet characterSetWithCharactersInString:@"-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz~"];
+    return [self stringByAddingPercentEncodingWithAllowedCharacters:allowed];
 }
 
 - (NSString*)unescapedString
 {
-    return [self stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    return [self stringByRemovingPercentEncoding];
 }
 
 - (NSString *)removeExcessWhitespace 
@@ -191,7 +191,7 @@
         NSArray *keyValuePairArray = [keyValuePairString componentsSeparatedByString:@"="];
         if ([keyValuePairArray count] < 2) continue; 
         NSString *key = [keyValuePairArray objectAtIndex:0];
-        NSString *value = [[keyValuePairArray objectAtIndex:1] stringByReplacingPercentEscapesUsingEncoding:NSASCIIStringEncoding];
+        NSString *value = [[keyValuePairArray objectAtIndex:1] unescapedString];
         [queryComponents setObject:value forKey:key];
     }
     return queryComponents;

--- a/IOSSharedTests/NSString+SDExtensionsTests.m
+++ b/IOSSharedTests/NSString+SDExtensionsTests.m
@@ -137,4 +137,20 @@
     XCTAssertTrue([@"1234567890-" isValidWithRegex:@"^\\d{10}?$"] == NO, @"The isValidWithRegex method did not recognize an invalid string.");
 }
 
+- (void)testPercentEncoding
+{
+    NSMutableString *unescaped = [NSMutableString string];
+
+    for (int c = 0; c < 128; c++) {
+        [unescaped appendFormat:@"%c", (char)c];
+    }
+
+    NSString *escaped = @"%01%02%03%04%05%06%07%08%09%0A%0B%0C%0D%0E%0F%10%11%12%13%14%15%16%17%18%19%1A%1B%1C%1D%1E%1F%20%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F0123456789%3A%3B%3C%3D%3E%3F%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~%7F";
+
+    XCTAssertEqualObjects([unescaped escapedString], escaped);
+    XCTAssertEqualObjects([escaped unescapedString], unescaped);
+    XCTAssertEqualObjects([[escaped unescapedString] escapedString], escaped);
+    XCTAssertEqualObjects([[unescaped escapedString] unescapedString], unescaped);
+}
+
 @end


### PR DESCRIPTION
#### What does this PR do?

Updates the code in the `NSString` extensions so that it does not produce deprecation warnings when targeting iOS 9.

#### Where should the reviewer start?

The changes are pretty straightforward. I used the following code to find the set of characters that were **not** escaped by the previous `CFURL` function call:

```objc
NSMutableString *raw = [NSMutableString string];

for (int c = 0; c < 256; c++) {
    [raw appendFormat:@"%c", (char)c];
}

NSString *escaped = [raw escapedString];
NSString *allowed = [escaped stringByReplacingOccurrencesOfString:@"\\%[0-9a-fA-F]{2}" withString:@"" options:NSRegularExpressionSearch range:NSMakeRange(0, escaped.length)];
```

#### How should this be manually tested?

I added a unit test that covers this code (for the ASCII range). The test passes when run against both the old and new code.

#### Anything else?

For characters outside the ASCII range, the output of `escapedString` differs, like:

**Old**:
```objc
[[NSString stringWithFormat:@"%c", (char)128] escapedString]; // => "%C2%80"
```

**New:**
```objc
[[NSString stringWithFormat:@"%c", (char)128] escapedString]; // => "%80"
```
I'm not sure which one is more correct.